### PR TITLE
Implemented resizing, related changes

### DIFF
--- a/WinkleWinkle_Extender_GUI_v1.3.3.xml
+++ b/WinkleWinkle_Extender_GUI_v1.3.3.xml
@@ -98,19 +98,27 @@ require "movewindow"
 require "mw"
 
 -- Initialize variables
+local background_colour = ColourNameToRGB("black")
 local cpList = {}
 local cpType = "none"
 local xcp_index_n = 0
 
+-- resizing constraints
+RESIZE_TAG_SIZE = 13		-- Size of the zone for resizing via drag
+REFRESH_DELAY = 0.066		-- Controls delay between Redraws while resizing.
+local win_minimum_width = 280
+local win_minimum_height = 40+RESIZE_TAG_SIZE
 -- window dimensions
-local win_height = 280
-local win_width = 280
+local win_width = tonumber(GetVariable("WinSizeX")) or 280
+local win_height = tonumber(GetVariable("WinSizeY")) or 280
 -- window position x,y coordinates
-local pos_x = GetVariable("WinPosX") or 0
-local pos_y = GetVariable("WinPosY") or 0
+local pos_x = tonumber(GetVariable("WinPosX")) or 0
+local pos_y = tonumber(GetVariable("WinPosY")) or 0
 -- window dimensions min/max
 local win_height_minimized = 45
-local win_height_maximized = 280
+local win_width_minimized = win_minimum_width
+local win_width_maximized = tonumber(GetVariable("WinMaxX")) or win_width_minimized
+local win_height_maximized = tonumber(GetVariable("WinMaxY")) or 280
 
 local win_state = GetVariable("WinState") or "max"
 local win_init = false
@@ -130,12 +138,8 @@ local USER_qq_report_channel = "gt" 			-- group tell
 function create_win()
 	if (win_init == false) then
 		win_init = true
-		WindowCreate (win, 0, 0, win_width, win_height, miniwin.pos_center_all, 0, ColourNameToRGB("black"))  -- create window
+		WindowCreate (win, windowinfo.window_left, windowinfo.window_top, win_width, win_height, windowinfo.window_mode, windowinfo.window_flags, background_colour)  -- create window
 		
-		-- move the window to the new location
-		WindowPosition(win, pos_x, pos_y, 
-			miniwin.pos_stretch_to_view, 
-			miniwin.create_absolute_location)			
 		WindowShow(win, true)  -- show it 
 
 		if (win_state == "min") then
@@ -152,11 +156,12 @@ function create_win()
 			CallPlugin(z_order_plugin, "registerMiniwindow", win)
 		end		
 		draw_window()	
+		add_resize_tag()
 	end
 end
 
 function draw_window()
-	WindowRectOp (win, miniwin.rect_fill, 0, 0, 0, 0, 0x000000)				-- Clear the window, which is the first step in updating it!
+	WindowRectOp (win, miniwin.rect_fill, 0, 0, 0, 0, background_colour)				-- Clear the window, which is the first step in updating it!
 	WindowRectOp (win, 2, 0, 0, 0, 17, 0x000000)						 	-- Draw title bar background and set color (almost black, "17" is height)
 	WindowRectOp (win, 4, 0, 0, 0, 17, 0xE0E0E0, 0x909090)					-- Draw title bar border (left/top = light grey, right/bottom = darker grey, "17" is height)
 	WindowRectOp (win, 1, 0, 0, 0, 0, 0xC0C0C0, 15)							-- Draw window border.
@@ -166,8 +171,9 @@ function draw_window()
 				5, 1, 200, 15,				-- left (x1), top (y1), right (x2), bottom (y2) values for window title text
 				0x80FFFF, 					-- colour (light yellow)
 				false)						-- not unicode
+
 	if (hotspots["hsDrag1"] == nil) then
-		hotspots["hsDrag1"] = WindowAddHotspot(win, "hsDrag1", 0, 0, 230, 16, -- hotspot id, rectangle (left, top, right, bottom)
+		hotspots["hsDrag1"] = WindowAddHotspot(win, "hsDrag1", 0, 0, win_width-20, 16, -- hotspot id, rectangle (left, top, right, bottom)
 					"mouseover", "cancelmouseover", "mousedown", "cancelmousedown", "mouseup", 
 					"Left click = Drag title bar to move\nRight click = Send window to front/back", miniwin.cursor_arrow, 0)
 		WindowDragHandler(win, "hsDrag1", "dragmove", "dragrelease", 0) 
@@ -224,6 +230,7 @@ function xgui_cplist_font_size(name, line, wildcards)
 		WindowFont(win, "cplist_room", "Segoe", cplist_font_size, false, false, false, false)					-- cp list font, room cp's
 		draw_window()
 		write_items("cp")
+		add_resize_tag()
 		Redraw()
 		print("Cp list font size set to " .. cplist_font_size .. ".\n")
 	end
@@ -236,6 +243,7 @@ function xgui_cplist_line_space(name, line, wildcards)
 		line_spacing = tonumber(wildcards.space)
 		draw_window()
 		write_items("cp")
+		add_resize_tag()
 		Redraw()
 		print("Cp list line spacing set to " .. line_spacing .. ".\n")
 	end
@@ -290,6 +298,8 @@ function write_list_items(list)
 	-- puts the campaign mob names into the list
 	local index = 0
 	for i,v in ipairs (list) do
+		-- Abort loop if printed item would not be visible.
+		if (tonumber(i) * line_spacing + offset > win_height - 5) then break end
 		index = index + 1
 		local qty = ""
 		if (v.qty > 1) then
@@ -346,7 +356,10 @@ function write_list_items(list)
 		local hsLength = (5 + width)
 		if (hsLength < 0) then hsLength = 0 end
 		local hsHeight = ((tonumber(i) * line_spacing) + 12 + offset)
-		if (hsHeight < 0) then hsHeight = 0 end
+		if (hsHeight < 0) then hsHeight = 0 elseif (tonumber(i) * line_spacing + offset + hsHeight > win_height - RESIZE_TAG_SIZE) then
+			-- Prevent list item's hotspot from overlapping with the resize tag
+			if (hsLength > win_width - RESIZE_TAG_SIZE) then hsLength = win_width - RESIZE_TAG_SIZE end
+		end
 		--Note(string.format("%s %s %s %s", 5, (tonumber(i) * line_spacing) + offset, hsLength, hsHeight))
 		local eventHandler
 		if (current_mode() == "cp") then
@@ -375,17 +388,20 @@ function OnPluginBroadcast (msg, id, name, text)
 			cpList = obj
 			draw_window()
 			write_items("cp")
+			add_resize_tag()
 			Redraw()
 		elseif (msg == 675) then	-- cp type
 			cpType = text
 			gui_filter_cplist(cpList)
 			draw_window()
 			write_items("cp")
+			add_resize_tag()
 			Redraw()
 		elseif (msg == 680) then	-- xcp index, tells GUI which list item to highlight
 			xcp_index_n = tonumber(text)
 			draw_window()
 			write_items("cp")
+			add_resize_tag()
 			Redraw()
 		end
 		
@@ -399,6 +415,79 @@ function current_mode()
 	else
 		return "gq"
 	end
+end
+
+function ResizeMoveCallback()
+	if GetPluginVariable("c293f9e7f04dde889f65cb90", "lock_down_miniwindows") == "1" then
+		return
+	end
+	posx, posy = WindowInfo (win, 17), WindowInfo (win, 18)
+	win_width = win_width + posx - startx
+	startx = posx
+	if (win_width < win_minimum_width) then
+		win_width = win_minimum_width
+		startx = windowinfo.window_left+win_width
+	elseif (windowinfo.window_left+win_width > GetInfo(281)) then
+		win_width = GetInfo(281)-windowinfo.window_left
+		startx = GetInfo(281)
+	end
+
+	win_height = win_height + posy - starty
+	starty = posy
+	if (win_height < win_minimum_height) then
+		win_height = win_minimum_height
+		starty = windowinfo.window_top+win_height
+	elseif (windowinfo.window_top+win_height > GetInfo(280)) then
+		win_height = GetInfo(280)-windowinfo.window_top
+		starty = GetInfo(280)
+	end
+	WindowResize(win, win_width, win_height, background_colour)
+	if (utils.timer() - lastRefresh > REFRESH_DELAY) then
+		draw_window()
+		write_items()
+		add_resize_tag()
+		Redraw()
+		lastRefresh = utils.timer()
+	end
+end
+
+lastRefresh = 0
+
+function ResizeReleaseCallback()
+	win_height_maximized = win_height
+	win_width_maximized = win_width
+	draw_window()
+	write_items()
+	add_resize_tag()
+	Redraw()
+end
+
+function add_resize_tag()
+	-- draw the resize widget bottom right corner, if not minimized
+	if (win_state == "max") then
+		WindowLine(win, win_width-3,  win_height-2, win_width-2, win_height-3, 0xffffff, 0, 2)
+		WindowLine(win, win_width-4,  win_height-2, win_width-2, win_height-4, 0x696969, 0, 1)
+		WindowLine(win, win_width-6,  win_height-2, win_width-2, win_height-6, 0xffffff, 0, 2)
+		WindowLine(win, win_width-7,  win_height-2, win_width-2, win_height-7, 0x696969, 0, 1)
+		WindowLine(win, win_width-9,  win_height-2, win_width-2, win_height-9, 0xffffff, 0, 2)
+		WindowLine(win, win_width-10, win_height-2, win_width-2, win_height-10, 0x696969, 0, 1)
+		WindowLine(win, win_width-12, win_height-2, win_width-2, win_height-12, 0xffffff, 0, 2)
+		WindowLine(win, win_width-13, win_height-2, win_width-2, win_height-13, 0x696969, 0, 1)
+	end
+
+	-- Hotspot for resizer.
+	if (WindowHotspotInfo(win, "hsResize", 1) == nil) then
+		WindowAddHotspot(win, "hsResize", win_width-RESIZE_TAG_SIZE, win_height-RESIZE_TAG_SIZE, win_width, win_height, "", "", "MouseDown", "", "", "", 6, 0)
+		WindowDragHandler(win, "hsResize", "ResizeMoveCallback", "ResizeReleaseCallback", 0)
+	else
+		WindowMoveHotspot(win, "hsResize", win_width-RESIZE_TAG_SIZE, win_height-RESIZE_TAG_SIZE, 0, 0)
+	end
+end
+
+function MouseDown(flags, hotspot_id)
+   if (hotspot_id == "hsResize") then
+      startx, starty = WindowInfo (win, 17), WindowInfo (win, 18)
+   end
 end
 
 -- When command button is clicked, this function sends appropriate command
@@ -439,20 +528,23 @@ function mouseup(flags, hotspot_id)
 		cpList = {}
 		draw_window()
 		write_items()
+		add_resize_tag()
 		Redraw()
 --	elseif (hotspot_id == "hsMinimize") then	-- minimize (dot) button in title bar
 --		win_state = "min"
 --		win_height = win_height_minimized
---		WindowResize(win, win_width, win_height, ColourNameToRGB("black"))
+--		WindowResize(win, win_width, win_height, background_colour)
 --		draw_window()
 --		write_items()
+--		add_resize_tag()
 --		Redraw()
 --	elseif (hotspot_id == "hsMaximize") then	-- maximize (carat) button in title bar
 --		win_state = "max"
 --		win_height = win_height_maximized
---		WindowResize(win, win_width, win_height, ColourNameToRGB("black"))
+--		WindowResize(win, win_width, win_height, background_colour)
 --		draw_window()
 --		write_items()
+--		add_resize_tag()
 --		Redraw()
 --	elseif (hotspot_id == "hsFront") then
 --		if (IsPluginInstalled(z_order_plugin) and GetPluginInfo(z_order_plugin, 17)) then
@@ -503,6 +595,7 @@ function do_trg_gq_line(name, line, wildcards)
 	EnableTrigger("trg_gq_line_end", true)
 	if (do_trg_gq_line_index == 0) then
 		draw_window()
+		add_resize_tag()
 	end
 	do_trg_gq_line_index = do_trg_gq_line_index + 1
 	local qty = ""
@@ -562,19 +655,34 @@ function dragrelease(flags, hotspot_id)
 end
 
 function OnPluginClose ()
+	OnPluginSaveState()
 	WindowShow(win, false) -- hide window, refresh screen
 end 
 
 function OnPluginSaveState()
+	-- save window current location for next time
+	movewindow.save_state (win)
+
+	if WindowInfo(win, 3) and WindowInfo(win, 4) then
+		win_width = WindowInfo(win, 3)
+		win_height = WindowInfo(win, 4)
+	end
 	SetVariable("WinPosX", pos_x)
 	SetVariable("WinPosY", pos_y)
 	SetVariable("WinState", win_state)
+	SetVariable("WinSizeX", win_width)
+	SetVariable("WinSizeY", win_height)
+	SetVariable("WinMaxX", win_width_maximized)
+	SetVariable("WinMaxY", win_height_maximized)
 end
 
-
--- run it all
-create_win()
-
+function OnPluginInstall()
+	--- install the window movement handler, get back the window position.
+	windowinfo = movewindow.install (win, miniwin.pos_center, miniwin.create_absolute_location, false, nil, {mouseup=MouseUp, mousedown=LeftClickOnly, dragmove=LeftClickOnly, dragrelease=LeftClickOnly},{x=pos_x, y=pos_y})
+	
+	-- run it all
+	create_win()
+end
 
 	-- S&D PLUGIN ID'S:
 	-- Mapper Extender			id="b6eae87ccedd84f510b74715"


### PR DESCRIPTION
Resizing is implemented with these changes.  No issues encountered when testing against these modifications, but try it out and let me know!

+ Add/modify variables to support resizing/redrawing procedure
* Initial WindowCreate now relies on WindowInfo variables from MoveWindow
+ Restore the original resize tag as separate function **add_resize_tag** (gets calls from multiple places)
* Titlebar hotspot now adjusts for variable window width
* Slight changes to target printing function **write_list_items**:
	* Target creation loop now aborts when current/subsequent items would not be visible in window
	* Hotspots created for targets will check for and avoid overlapping with the resize tag
+ Import and adapt **ResizeMoveCallback**, **ResizeReleaseCallback**, **add_resize_tag**, and **MouseDown** from Fiendish's plugins
	* Thanks, Fiendish!
+ Minor additions to disabled functions to support other changes being made, in case they get re-imp'd
* Move plugin's initial calls to OnPluginInstall()